### PR TITLE
Initial UA-ULTRA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - Unifi Access Hub (UAH) :white_check_mark:
 - Unifi Access Hub Enterprise (UAH-Ent) :x: (partial/experimental support)
 - Unifi Gate Hub (UGT) :x: (partial/experimental support)
+- Unifi Access Ultra :x: (partial/experimental support)
 
 # Getting Unifi Access API Token
 - Log in to Unifi Access and Click on Security -> Advanced -> API Token

--- a/custom_components/unifi_access/door.py
+++ b/custom_components/unifi_access/door.py
@@ -56,6 +56,9 @@ class UnifiAccessDoor:
     @property
     def is_locked(self):
         """Solely used for locked state when calling lock."""
+        if self.door_lock_relay_status == "" :
+            self.door_lock_relay_status = "lock"
+            _LOGGER.warning("door.py: self.door_lock_relay_status not set - assuming locked")
         return self.door_lock_relay_status == "lock"
 
     @property

--- a/custom_components/unifi_access/hub.py
+++ b/custom_components/unifi_access/hub.py
@@ -431,6 +431,8 @@ class UnifiAccessHub:
                 return self._handle_UAH_config_update(update, device_type)
             case "UAH-Ent":
                 return self._handle_UAH_Ent_config_update(update, device_type)
+            case "UA-ULTRA":
+                return self._handle_UAH_Ent_config_update(update, device_type)
             case "UGT":
                 return self._handle_UGT_config_update(update, device_type)
 


### PR DESCRIPTION
Directly using the Enterprise Hub code from the evacuation_lock_down_temp_lock_rules branch works, just with unneeded DPS and doorbell entities, (and "None" in the entity name where the Enterprise hub would I assume have a door number?). I don't know if you'd want to duplicate that code again for the UA-ULTRA, or make it a bit more generic in a single function instead?

Only issue is the door status on HA restart is always "unlocked", so HA will not allow an unlock operation until the first websocket data update from UA, which correctly sets the lock/unlock status. As a quick and dirty fix, assuming locked status when there is blank data for lock status.

#56 