### PR TITLE
Added UAH-DOOR device_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 # Supported hardware
 - Unifi Access Hub (UAH) :white_check_mark:
+- Unifi Access Hub (UAH-DOOR) :white_check_mark:
 - Unifi Access Hub Enterprise (UAH-Ent) :x: (partial/experimental support)
 - Unifi Gate Hub (UGT) :x: (partial/experimental support)
 - Unifi Access Ultra :x: (partial/experimental support)

--- a/custom_components/unifi_access/hub.py
+++ b/custom_components/unifi_access/hub.py
@@ -442,6 +442,8 @@ class UnifiAccessHub:
         match device_type:
             case "UAH":
                 return self._handle_UAH_config_update(update, device_type)
+            case "UAH-DOOR":
+                return self._handle_UAH_config_update(update, device_type)
             case "UAH-Ent":
                 return self._handle_UAH_Ent_config_update(update, device_type)
             case "UA-ULTRA":

--- a/custom_components/unifi_access/hub.py
+++ b/custom_components/unifi_access/hub.py
@@ -432,6 +432,11 @@ class UnifiAccessHub:
             changed_doors.append(existing_door)
         return changed_doors
 
+    def _handle_UNKNOWN_config_update(self, update, device_type):
+        """Default handler for unknown hub types"""
+        _LOGGER.critical("UniFi Access Hub type %s unknown", device_type)
+        _LOGGER.critical("%s", update)
+
     def _handle_config_update(self, update, device_type):
         """Process config update."""
         match device_type:
@@ -443,6 +448,8 @@ class UnifiAccessHub:
                 return self._handle_UAH_Ent_config_update(update, device_type)
             case "UGT":
                 return self._handle_UGT_config_update(update, device_type)
+            case _:
+                return self._handle_UNKNOWN_config_update(update, device_type)
 
     def on_message(self, ws: websocket.WebSocketApp, message):  # noqa: C901
         """Handle messages received on the websocket client.


### PR DESCRIPTION
Newer Access Hubs (the ones with 4 ethernet ports) are self-identified as UAH-DOOR, vs the original UAH device_type.
#64 