### PR TITLE
Added Credential Provider for the access.logs.add event

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ An entity will get created for each door. Every time a door is accessed (entry, 
 ### Event metadata
 - door_name
 - door_id
+- authentication # this is the method used to initiate the event ("REMOTE_THROUGH_UAH" , "NFC" , "MOBILE_TAP" , "PIN_CODE")
 - actor # this is the name of the user that accessed the door. If set to N/A that means UNAUTHORIZED ACCESS!
 - type # `unifi_access_entry` or `unifi_access_exit`
 

--- a/custom_components/unifi_access/hub.py
+++ b/custom_components/unifi_access/hub.py
@@ -600,7 +600,7 @@ class UnifiAccessHub:
                                     "type": ACCESS_EVENT.format(type=access_type),
                                 }
                                 _LOGGER.info(
-                                    "Door name %s with id %s accessed by %s. access type: %s",
+                                    "Door name %s with id %s accessed by %s. authentication %s, access type: %s",
                                     existing_door.name,
                                     door_id,
                                     actor,

--- a/custom_components/unifi_access/hub.py
+++ b/custom_components/unifi_access/hub.py
@@ -579,6 +579,8 @@ class UnifiAccessHub:
                         if door_id in self.doors:
                             existing_door = self.doors[door_id]
                             actor = update["data"]["_source"]["actor"]["display_name"]
+                            #"REMOTE_THROUGH_UAH" , "NFC" , "MOBILE_TAP" , "PIN_CODE"
+                            authentication = update["data"]["_source"]["authentication"]["credential_provider"]
                             device_config = next(
                                 (
                                     target
@@ -594,6 +596,7 @@ class UnifiAccessHub:
                                     "door_name": existing_door.name,
                                     "door_id": door_id,
                                     "actor": actor,
+                                    "authentication": authentication,
                                     "type": ACCESS_EVENT.format(type=access_type),
                                 }
                                 _LOGGER.info(
@@ -601,6 +604,7 @@ class UnifiAccessHub:
                                     existing_door.name,
                                     door_id,
                                     actor,
+                                    authentication,
                                     access_type,
                                 )
                             changed_doors.append(existing_door)


### PR DESCRIPTION
added ability to determine how the actor has initiated the access event - remotely (through access app or viewer) or at the reader itself with a phone or nfc card. 