### PR TITLE
Ignore interface devices

### DIFF
--- a/custom_components/unifi_access/hub.py
+++ b/custom_components/unifi_access/hub.py
@@ -432,6 +432,11 @@ class UnifiAccessHub:
             changed_doors.append(existing_door)
         return changed_doors
 
+    def _handle_IGNORED_config_update(self, update, device_type):
+        """Handle unknown hub types."""
+        _LOGGER.debug("UniFi Access Hub type %s ignored", device_type)
+        _LOGGER.debug("%s", update)
+
     def _handle_UNKNOWN_config_update(self, update, device_type):
         """Handle unknown hub types."""
         _LOGGER.critical("UniFi Access Hub type %s unknown", device_type)
@@ -444,14 +449,18 @@ class UnifiAccessHub:
                 return self._handle_UAH_config_update(update, device_type)
             case "UAH-DOOR":
                 return self._handle_UAH_config_update(update, device_type)
-            case "UA-Intercom":
-                return self._handle_UAH_config_update(update, device_type)
             case "UAH-Ent":
                 return self._handle_UAH_Ent_config_update(update, device_type)
             case "UA-ULTRA":
                 return self._handle_UAH_Ent_config_update(update, device_type)
             case "UGT":
                 return self._handle_UGT_config_update(update, device_type)
+            case "UA-G2":
+                return self._handle_IGNORED_config_update(update, device_type)
+            case "UA-G2-PRO":
+                return self._handle_IGNORED_config_update(update, device_type)
+            case "UA-Intercom":
+                return self._handle_IGNORED_config_update(update, device_type)
             case _:
                 return self._handle_UNKNOWN_config_update(update, device_type)
 
@@ -579,8 +588,6 @@ class UnifiAccessHub:
                         if door_id in self.doors:
                             existing_door = self.doors[door_id]
                             actor = update["data"]["_source"]["actor"]["display_name"]
-                            #"REMOTE_THROUGH_UAH" , "NFC" , "MOBILE_TAP" , "PIN_CODE"
-                            authentication = update["data"]["_source"]["authentication"]["credential_provider"]
                             device_config = next(
                                 (
                                     target
@@ -596,15 +603,13 @@ class UnifiAccessHub:
                                     "door_name": existing_door.name,
                                     "door_id": door_id,
                                     "actor": actor,
-                                    "authentication": authentication,
                                     "type": ACCESS_EVENT.format(type=access_type),
                                 }
                                 _LOGGER.info(
-                                    "Door name %s with id %s accessed by %s. authentication %s, access type: %s",
+                                    "Door name %s with id %s accessed by %s. access type: %s",
                                     existing_door.name,
                                     door_id,
                                     actor,
-                                    authentication,
                                     access_type,
                                 )
                             changed_doors.append(existing_door)

--- a/custom_components/unifi_access/hub.py
+++ b/custom_components/unifi_access/hub.py
@@ -588,6 +588,8 @@ class UnifiAccessHub:
                         if door_id in self.doors:
                             existing_door = self.doors[door_id]
                             actor = update["data"]["_source"]["actor"]["display_name"]
+                            #"REMOTE_THROUGH_UAH" , "NFC" , "MOBILE_TAP" , "PIN_CODE"
+                            authentication = update["data"]["_source"]["authentication"]["credential_provider"]
                             device_config = next(
                                 (
                                     target
@@ -603,13 +605,15 @@ class UnifiAccessHub:
                                     "door_name": existing_door.name,
                                     "door_id": door_id,
                                     "actor": actor,
+                                    "authentication": authentication,
                                     "type": ACCESS_EVENT.format(type=access_type),
                                 }
                                 _LOGGER.info(
-                                    "Door name %s with id %s accessed by %s. access type: %s",
+                                    "Door name %s with id %s accessed by %s. authentication %s, access type: %s",
                                     existing_door.name,
                                     door_id,
                                     actor,
+                                    authentication,
                                     access_type,
                                 )
                             changed_doors.append(existing_door)


### PR DESCRIPTION
Updates access.data.device.update handling so updates from the UA-Intercom, UA-G2, and UA-G2-PRO are ignored, since they aren't able to actually control a door or gate directly.  The contents of the update message are still logged (as debug) in case the info is needed when trying to develop new features in the future.

Note: this will fix #84 and #79