### PR TITLE
Add door entry/exit result to access event attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ An entity will get created for each door. Every time a door is accessed (entry, 
 - door_name
 - door_id
 - authentication # this is the method used to initiate the event ("REMOTE_THROUGH_UAH" , "NFC" , "MOBILE_TAP" , "PIN_CODE")
-- actor # this is the name of the user that accessed the door. If set to N/A that means UNAUTHORIZED ACCESS!
+- actor # this is the name of the user that accessed the door. If set to N/A that means UNAUTHORIZED ACCESS! In some cases actor may still be set. Check the result value. 
 - type # `unifi_access_entry` or `unifi_access_exit`
+- result # the result of the entry/exit event ("ACCESS" , "BLOCKED" , "INCOMPLETE") There may be other values.
 
 ### Evacuation/Lockdown
 The evacuation (unlock all doors) and lockdown (lock all doors) switches apply to all doors and gates and **will sound the alarm** no matter which configuration you currently have in your terminal settings. The status will not update currently (known issue).

--- a/custom_components/unifi_access/hub.py
+++ b/custom_components/unifi_access/hub.py
@@ -444,6 +444,7 @@ class UnifiAccessHub:
                         if door_id in self.doors:
                             existing_door = self.doors[door_id]
                             actor = update["data"]["_source"]["actor"]["display_name"]
+                            result = update["data"]["_source"]["event"]["result"]
                             # "REMOTE_THROUGH_UAH" , "NFC" , "MOBILE_TAP" , "PIN_CODE"
                             authentication = update["data"]["_source"][
                                 "authentication"
@@ -465,14 +466,16 @@ class UnifiAccessHub:
                                     "actor": actor,
                                     "authentication": authentication,
                                     "type": ACCESS_EVENT.format(type=access_type),
+                                    "result": result,
                                 }
                                 _LOGGER.info(
-                                    "Door name %s with id %s accessed by %s. authentication %s, access type: %s",
+                                    "Door name %s with id %s accessed by %s. authentication %s, access type: %s, result: %s",
                                     existing_door.name,
                                     door_id,
                                     actor,
                                     authentication,
                                     access_type,
+                                    result,
                                 )
                 case "access.hw.door_bell":
                     door_id = update["data"]["door_id"]


### PR DESCRIPTION
In some cases the access event may contain an actor name even if the actor is not granted access. This depends on the door access policy/schedule. In this case we can use the result value to determine if the door was unlocked or not.

Updated the event attributes to include the result value.