### PR TITLE
Fix door lock context and remove duplicate select options

### DIFF
--- a/custom_components/unifi_access/lock.py
+++ b/custom_components/unifi_access/lock.py
@@ -45,7 +45,7 @@ class UnifiDoorLockEntity(CoordinatorEntity, LockEntity):
 
     def __init__(self, coordinator, door_id) -> None:
         """Initialize Unifi Access Door Lock."""
-        super().__init__(coordinator, context=id)
+        super().__init__(coordinator, context=door_id)
         self.door: UnifiAccessDoor = self.coordinator.data[door_id]
         self._attr_unique_id = self.door.id
         self._attr_translation_placeholders = {"door_name": self.door.name}

--- a/custom_components/unifi_access/select.py
+++ b/custom_components/unifi_access/select.py
@@ -74,15 +74,21 @@ class TemporaryLockRuleSelectEntity(CoordinatorEntity, SelectEntity):
         return self.door.lock_rule
 
     def _update_options(self):
-        "Update Door Lock Rules."
+        "Update Door Lock Rules without duplications."
         self._attr_current_option = self.coordinator.data[self.door.id].lock_rule
-        if (
-            self._attr_current_option != "schedule"
-            and "lock_early" in self._attr_options
-        ):
-            self._attr_options.remove("lock_early")
-        else:
-            self._attr_options.append("lock_early")
+
+        base_options = [
+            "",
+            "keep_lock",
+            "keep_unlock",
+            "custom",
+            "reset",
+        ]
+
+        if self._attr_current_option == "schedule":
+            base_options.append("lock_early")
+
+        self._attr_options = base_options
 
     async def async_select_option(self, option: str) -> None:
         "Select Door Lock Rule."


### PR DESCRIPTION
## Summary
- ensure door lock entity registers with correct context
- avoid duplicating the `lock_early` option when updating lock rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd7a86eec832a994032449ce0858f