### PR TITLE
Fix access.logs.add event handling for device ID mismatch

### DIFF
--- a/custom_components/unifi_access/door.py
+++ b/custom_components/unifi_access/door.py
@@ -37,6 +37,7 @@ class UnifiAccessDoor:
         self.lock_rule = door_lock_rule
         self.lock_rule_interval = 10
         self.lock_rule_ended_time = door_lock_rule_ended_time
+        self.device_ids = []  #added to not rely on dymamic assignment in _handle_location_upate_v2
         self.thumbnail = (
             b"\x89PNG\r\n\x1a\n"
             b"\x00\x00\x00\rIHDR\x00\x00\x00\x01"


### PR DESCRIPTION
Fixes an issue where the `access.logs.add` event fails to trigger `unifi_access_entry` due to a mismatch between the device ID (e.g., `f492bf76bc59`) in the event and the location ID (e.g., `207d7969-c9b6-4ac1-a567-98b6a68bf696`) in `self.doors`. The handler now maps the device ID to the location ID using `door.device_ids` from `access.data.v2.location.update`. Updated `_handle_location_update_v2` in `hub.py` to store `device_ids`. Added `device_ids` to `UnifiAccessDoor` in `door.py` for robustness.

Tested with a remote unlock event, confirming `unifi_access_entry` fires correctly with the location ID.

Log example:
[2025-09-07 17:23:15.168] {"event":"access.logs.add","receiver_id":"","event_object_id":"f492bf76bc59","save_to_history":false,"data":{"_id":"","@timestamp":"","_source":{"actor":{"id":"aaffa6e1-5e8a-4213-bf6e-f5d719843dec","type":"user","display_name":"Jeff Blattel","first_name":"Jeff","last_name":"Blattel"},"event":{"type":"access.door.unlock","display_message":"Access Granted (Remote)","result":"ACCESS","published":1757290993000,"log_key":"dashboard.access.door.unlock.success","log_category":"Unlocks"},"authentication":{"credential_provider":"REMOTE_THROUGH_UAH"},"target":[{"type":"UAH","id":"f492bf76bc59","display_name":"UA-HUB-BC59"},{"type":"device_config","id":"door_entry_method","display_name":"entry"},{"type":"door","id":"f492bf76bc59","display_name":"Main Gate"},...]}}}

Related issue: https://github.com/imhotep/hass-unifi-access/issues/140