### PR TITLE
device/door association - lock_now event - various fixes

### DIFF
--- a/custom_components/unifi_access/binary_sensor.py
+++ b/custom_components/unifi_access/binary_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
@@ -23,7 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Add binary_sensor entity for passed config entry."""
     hub: UnifiAccessHub = hass.data[DOMAIN][config_entry.entry_id]

--- a/custom_components/unifi_access/door.py
+++ b/custom_components/unifi_access/door.py
@@ -29,6 +29,7 @@ class UnifiAccessDoor:
         self._is_unlocking = False
         self._hub = hub
         self.hub_type = "UAH"
+        self.hub_id = None
         self._id = door_id
         self.name = name
         self.door_position_status = door_position_status
@@ -155,6 +156,7 @@ class UnifiAccessDoor:
                 self.id == value.id
                 and self.name == value.name
                 and self.hub_type == value.hub_type
+                and self.hub_id == value.hub_id
                 and self.door_position_status == value.door_position_status
                 and self.door_lock_relay_status == value.door_lock_relay_status
                 and self.lock_rule == value.lock_rule
@@ -164,4 +166,4 @@ class UnifiAccessDoor:
 
     def __repr__(self):
         """Return string representation of door."""
-        return f"<UnifiAccessDoor id={self.id} name={self.name} hub_type={self.hub_type} door_position_status={self.door_position_status} door_lock_relay_status={self.door_lock_relay_status} lock_rule={self.lock_rule} lock_rule_ended_time={self.lock_rule_ended_time}>"
+        return f"<UnifiAccessDoor id={self.id} name={self.name} hub_type={self.hub_type} hub_id={self.hub_id} door_position_status={self.door_position_status} door_lock_relay_status={self.door_lock_relay_status} lock_rule={self.lock_rule} lock_rule_ended_time={self.lock_rule_ended_time}>"

--- a/custom_components/unifi_access/event.py
+++ b/custom_components/unifi_access/event.py
@@ -8,7 +8,7 @@ from homeassistant.components.event import EventDeviceClass, EventEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import (
     ACCESS_ENTRY_EVENT,
@@ -26,7 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Add event entity for passed config entry."""
     hub: UnifiAccessHub = hass.data[DOMAIN][config_entry.entry_id]

--- a/custom_components/unifi_access/image.py
+++ b/custom_components/unifi_access/image.py
@@ -9,7 +9,7 @@ from homeassistant.components.image import ImageEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
 from .door import UnifiAccessDoor
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Add image entity for passed config entry."""
 

--- a/custom_components/unifi_access/lock.py
+++ b/custom_components/unifi_access/lock.py
@@ -9,7 +9,7 @@ from homeassistant.components.lock import LockEntity, LockEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Add lock entity for passed config entry."""
 

--- a/custom_components/unifi_access/manifest.json
+++ b/custom_components/unifi_access/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "websocket-client==1.8.0"
   ],
-  "version": "1.2.8"
+  "version": "1.2.9"
 }

--- a/custom_components/unifi_access/number.py
+++ b/custom_components/unifi_access/number.py
@@ -6,7 +6,7 @@ from homeassistant.components.number import RestoreNumber
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
 from .door import UnifiAccessDoor
@@ -18,7 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Add number entity for passed config entry."""
     hub: UnifiAccessHub = hass.data[DOMAIN][config_entry.entry_id]

--- a/custom_components/unifi_access/select.py
+++ b/custom_components/unifi_access/select.py
@@ -4,7 +4,7 @@ from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
@@ -16,7 +16,7 @@ from .hub import UnifiAccessHub
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Add select entity for passed config entry."""
     hub: UnifiAccessHub = hass.data[DOMAIN][config_entry.entry_id]
@@ -55,6 +55,7 @@ class TemporaryLockRuleSelectEntity(CoordinatorEntity, SelectEntity):
             "custom",
             "reset",
             "lock_early",
+            "lock_now",
         ]
         self._update_options()
 

--- a/custom_components/unifi_access/sensor.py
+++ b/custom_components/unifi_access/sensor.py
@@ -6,7 +6,7 @@ from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
 from .door import UnifiAccessDoor
@@ -16,7 +16,7 @@ from .hub import UnifiAccessHub
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Add sensor entity for passed config entry."""
     hub: UnifiAccessHub = hass.data[DOMAIN][config_entry.entry_id]

--- a/custom_components/unifi_access/strings.json
+++ b/custom_components/unifi_access/strings.json
@@ -78,7 +78,8 @@
           "keep_unlock": "Keep it unlocked",
           "custom": "Custom (set interval)",
           "reset": "Reset rule",
-          "lock_early": "Lock early"
+          "lock_early": "Lock early",
+          "lock_now": "Lock now"
         }
       }
     }

--- a/custom_components/unifi_access/switch.py
+++ b/custom_components/unifi_access/switch.py
@@ -7,7 +7,7 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
@@ -20,7 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Add switch entity for passed config entry."""
     hub: UnifiAccessHub = hass.data[DOMAIN][config_entry.entry_id]


### PR DESCRIPTION
Device door association - each door is now associated with a `hub type` and `hub id`

`lock_now` event - updating `async_entry` types to conform with new HA types

workaround/fix https://github.com/imhotep/hass-unifi-access/issues/140 
The API  obviously has a bug in the access.log.add event because the `device id` and `floor id` are correct but the door id is very obviously WRONG.