### PR TITLE
Add hub_id fallback to _handle_logs_add

### DIFF
--- a/custom_components/unifi_access/hub.py
+++ b/custom_components/unifi_access/hub.py
@@ -443,7 +443,24 @@ class UnifiAccessHub:
 
         state = self.doors.get(door_target.id)
         if state is None:
-            return
+            _LOGGER.debug(
+                "Potential buggy version of unifi access api detected - looking for door by hub id %s",
+                door_target.id,
+            )
+            state = next(
+                (
+                    door
+                    for door in self.doors.values()
+                    if getattr(door, "hub_id", None) == door_target.id
+                ),
+                None,
+            )
+            if state is None:
+                _LOGGER.warning(
+                    "Could not find door for log event with door id %s (or hub id)",
+                    door_target.id,
+                )
+                return
 
         access_type = device_config.display_name.lower()
         if access_type == "entry":

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -570,6 +570,53 @@ class TestHubWebSocketHandlers:
         # Should not trigger any state updates
         hub.on_doors_updated.assert_not_called()
 
+    async def test_handle_logs_add_falls_back_to_hub_id(
+        self, hub: UnifiAccessHub
+    ) -> None:
+        """logs.add should resolve a door by hub_id when the reported id is a hub id."""
+        hub.doors["door-001"].hub_id = "hub-001"
+
+        msg = MagicMock()
+        msg.data.source.target = [MagicMock(type="door", id="hub-001")]
+        msg.data.source.actor.display_name = "Raphael"
+        msg.data.source.event.result = "ACCESS"
+        msg.data.source.authentication.credential_provider = "FACE"
+        msg.data.source.device_config.display_name = "entry"
+
+        events_received = []
+        hub.doors["door-001"].add_event_listener(
+            "access", lambda e, a: events_received.append(a)
+        )
+
+        await hub._handle_logs_add(msg)
+
+        assert len(events_received) == 1
+        assert events_received[0]["door_id"] == "door-001"
+        assert events_received[0]["door_name"] == "Front Door"
+        assert events_received[0]["type"] == "unifi_access_entry"
+        hub.on_doors_updated.assert_not_called()
+
+    async def test_handle_logs_add_unknown_door(
+        self, hub: UnifiAccessHub
+    ) -> None:
+        """logs.add for a door not found by id or hub_id should be silently dropped."""
+        msg = MagicMock()
+        msg.data.source.target = [MagicMock(type="door", id="door-unknown")]
+        msg.data.source.actor.display_name = "Test"
+        msg.data.source.event.result = "ACCESS"
+        msg.data.source.authentication.credential_provider = "NFC"
+
+        events_received = []
+        for door_state in hub.doors.values():
+            door_state.add_event_listener(
+                "access", lambda e, a: events_received.append(a)
+            )
+
+        await hub._handle_logs_add(msg)
+
+        assert len(events_received) == 0
+        hub.on_doors_updated.assert_not_called()
+
     async def test_handle_logs_add_logging_only(
         self, hub: UnifiAccessHub
     ) -> None:


### PR DESCRIPTION
## Summary

The UniFi Access API is buggy and sometimes reports the hub id instead of the door id in `logs.add` websocket messages. This same issue was already handled in `_handle_insights_add` (L516-L536), and this PR applies the same fallback pattern to `_handle_logs_add`.

## Changes

- **`hub.py`**: When a door cannot be found by its reported id in `_handle_logs_add`, search all known doors for a matching `hub_id` before giving up (mirrors the existing logic in `_handle_insights_add`).
- **`tests/test_hub.py`**: Added two new tests:
  - `test_handle_logs_add_falls_back_to_hub_id` — verifies the buggy-API path resolves correctly and fires the event
  - `test_handle_logs_add_unknown_door` — verifies a completely unknown door is silently dropped