### PR TITLE
add example for listening to events.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,11 @@ You are able to select one of the following rules via the `input_select`:
 - **lock_early**: locks the door if it's currently on an unlock schedule.
 - **lock_now**: locks the door if it's currently on an unlock schedule OR if it's unlocked temporarily via a locking rule.
 
-# Example automation
+# Example automations
 
-```
+## Unlock door
+
+```yaml
 alias: Unlock Front Gate when motion is detected in Entryway
 description: ""
 trigger:
@@ -116,6 +118,28 @@ action:
     data: {}
     target:
       device_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+mode: single
+```
+
+## Use event as automation trigger
+
+Listen to a door event entity and use the event data to send a notification whenever someone accesses a door.
+
+```yaml
+alias: Announce person having opened the street door
+description: ""
+triggers:
+  - trigger: state
+    entity_id:
+      - event.front_door_unifi_door_event
+variables:
+  actor: "{{ trigger.to_state.attributes.get('actor', 'Unknown') }}"
+  door_name: "{{ trigger.to_state.attributes.get('door_name', 'Unknown') }}"
+actions:
+  - action: notify.mobile_app_my_phone
+    data:
+      title: Door opened
+      message: "{{ actor }} has opened {{ door_name }}."
 mode: single
 ```
 # API Limitations

--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ alias: Announce person having opened a Unifi door
 description: ""
 triggers:
   - platform: event
-    event_type: unifi_access_entry
-  - platform: event
-    event_type: unifi_access_access
+    event_type: 
+      - unifi_access_entry
+      - unifi_access_access
 variables:
   actor: "{{ trigger.event.data.actor or 'Unknown' }}"
   door_name: "{{ trigger.event.data.door_name or 'Unknown' }}"

--- a/README.md
+++ b/README.md
@@ -123,18 +123,19 @@ mode: single
 
 ## Use event as automation trigger
 
-Listen to a door event entity and use the event data to send a notification whenever someone accesses a door.
+Listen to Unifi Access events and use the event data to send a notification whenever someone accesses a door.
 
 ```yaml
-alias: Announce person having opened the street door
+alias: Announce person having opened a Unifi door
 description: ""
 triggers:
-  - trigger: state
-    entity_id:
-      - event.front_door_unifi_door_event
+  - platform: event
+    event_type: unifi_access_entry
+  - platform: event
+    event_type: unifi_access_access
 variables:
-  actor: "{{ trigger.to_state.attributes.get('actor', 'Unknown') }}"
-  door_name: "{{ trigger.to_state.attributes.get('door_name', 'Unknown') }}"
+  actor: "{{ trigger.event.data.actor or 'Unknown' }}"
+  door_name: "{{ trigger.event.data.door_name or 'Unknown' }}"
 actions:
   - action: notify.mobile_app_my_phone
     data:


### PR DESCRIPTION
Adds an example to readme.md to show how to access events.

I think these are not super common to use, so having something to point in the right direction is helpful (it would have saved me opening an issue)