### PR TITLE
release: bump py-unifi-access to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Improved international character support for German, French, and other languages
 
+## [3.0.6] - 2026-05-17
+
+### Fixed
+- Updated `py-unifi-access` to 1.2.0 to handle websocket device update payloads where `category` can be `null`
+
 ## [1.3.2] - 2024-10-21
 
 ### Changed

--- a/custom_components/unifi_access/manifest.json
+++ b/custom_components/unifi_access/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/imhotep/hass-unifi-access/blob/main/README.md",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/imhotep/hass-unifi-access/issues",
-  "requirements": ["py-unifi-access==1.1.3"],
-  "version": "3.0.5"
+  "requirements": ["py-unifi-access==1.2.0"],
+  "version": "3.0.6"
 }


### PR DESCRIPTION
## Summary
- bump the pinned \ dependency to 1.2.0
- bump the integration version to 3.0.6
- document the websocket validation fix in the changelog

## Why
This picks up the upstream websocket fix for \ payloads where \ can be \, which is the source of the logged error in #212.

Closes #212