### PR TITLE
fix: support standard ring event type for doorbell event entities

### DIFF
--- a/custom_components/unifi_access/event.py
+++ b/custom_components/unifi_access/event.py
@@ -78,11 +78,18 @@ class AccessEventEntity(_UnifiAccessEventEntity):
         self._attr_unique_id = f"{self.door.id}_access"
 
 
+try:
+    from homeassistant.components.event import DoorbellEventType
+    DOORBELL_RING_EVENT = DoorbellEventType.RING
+except ImportError:
+    DOORBELL_RING_EVENT = "ring"
+
+
 class DoorbellPressedEventEntity(_UnifiAccessEventEntity):
     """Doorbell Press Event Entity."""
 
     _attr_device_class = EventDeviceClass.DOORBELL
-    _attr_event_types = [DOORBELL_START_EVENT, DOORBELL_STOP_EVENT]  # noqa: RUF012
+    _attr_event_types = [DOORBELL_START_EVENT, DOORBELL_STOP_EVENT, DOORBELL_RING_EVENT]  # noqa: RUF012
     _attr_translation_key = "doorbell_event"
     _event_name = "doorbell_press"
 
@@ -90,3 +97,11 @@ class DoorbellPressedEventEntity(_UnifiAccessEventEntity):
         """Initialize doorbell event entity."""
         super().__init__(door)
         self._attr_unique_id = f"{self.door.id}_doorbell_press"
+
+    def _async_handle_event(self, event: str, event_attributes: dict[str, str]) -> None:
+        """Handle incoming event from hub."""
+        event_type = event_attributes.get("type", event)
+        self._trigger_event(event_type, event_attributes)
+        if event_type == DOORBELL_START_EVENT:
+            self._trigger_event(DOORBELL_RING_EVENT, event_attributes)
+        self.async_write_ha_state()

--- a/custom_components/unifi_access/strings.json
+++ b/custom_components/unifi_access/strings.json
@@ -77,7 +77,8 @@
           "event_type": {
             "state": {
               "unifi_access_doorbell_start": "Doorbell Start",
-              "unifi_access_doorbell_stop": "Doorbell Stop"
+              "unifi_access_doorbell_stop": "Doorbell Stop",
+              "ring": "Ring"
             }
           }
         }

--- a/custom_components/unifi_access/translations/de.json
+++ b/custom_components/unifi_access/translations/de.json
@@ -77,7 +77,8 @@
                     "event_type": {
                         "state": {
                             "unifi_access_doorbell_start": "Klingel Start",
-                            "unifi_access_doorbell_stop": "Klingel Stop"
+                            "unifi_access_doorbell_stop": "Klingel Stop",
+                            "ring": "Läuten"
                         }
                     }
                 }

--- a/custom_components/unifi_access/translations/en.json
+++ b/custom_components/unifi_access/translations/en.json
@@ -77,7 +77,8 @@
                     "event_type": {
                         "state": {
                             "unifi_access_doorbell_start": "Doorbell Start",
-                            "unifi_access_doorbell_stop": "Doorbell Stop"
+                            "unifi_access_doorbell_stop": "Doorbell Stop",
+                            "ring": "Ring"
                         }
                     }
                 }

--- a/custom_components/unifi_access/translations/it.json
+++ b/custom_components/unifi_access/translations/it.json
@@ -77,7 +77,8 @@
                     "event_type": {
                         "state": {
                             "unifi_access_doorbell_start": "Campanello Inizio",
-                            "unifi_access_doorbell_stop": "Campanello Fine"
+                            "unifi_access_doorbell_stop": "Campanello Fine",
+                            "ring": "Suona"
                         }
                     }
                 }

--- a/custom_components/unifi_access/translations/nl.json
+++ b/custom_components/unifi_access/translations/nl.json
@@ -77,7 +77,8 @@
                     "event_type": {
                         "state": {
                             "unifi_access_doorbell_start": "Deurbel Start",
-                            "unifi_access_doorbell_stop": "Deurbel Stop"
+                            "unifi_access_doorbell_stop": "Deurbel Stop",
+                            "ring": "Bellen"
                         }
                     }
                 }

--- a/custom_components/unifi_access/translations/zh-Hans.json
+++ b/custom_components/unifi_access/translations/zh-Hans.json
@@ -77,7 +77,8 @@
                     "event_type": {
                         "state": {
                             "unifi_access_doorbell_start": "门铃开始",
-                            "unifi_access_doorbell_stop": "门铃停止"
+                            "unifi_access_doorbell_stop": "门铃停止",
+                            "ring": "响起"
                         }
                     }
                 }

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -232,6 +232,47 @@ class TestEventPlatform:
         # 2 access events + 2 doorbell events = 4
         assert len(event_entities) == 4
 
+    async def test_doorbell_event_types(
+        self, hass: HomeAssistant, setup_integration
+    ) -> None:
+        """Doorbell event entity should support the ring event type."""
+        doorbell_state = next(
+            s
+            for s in hass.states.async_all()
+            if s.domain == "event" and s.object_id.endswith("doorbell_press")
+        )
+        assert "ring" in doorbell_state.attributes.get("event_types", [])
+
+    async def test_doorbell_press_triggers_ring(
+        self, hass: HomeAssistant, setup_integration
+    ) -> None:
+        """Test that triggering a doorbell press starts a ring event."""
+        entry, _ = setup_integration
+        hub = entry.runtime_data.hub
+
+        doorbell_entity_id = next(
+            s.entity_id
+            for s in hass.states.async_all()
+            if s.domain == "event" and s.object_id.endswith("doorbell_press")
+        )
+
+        # Initially, event_type should not be set
+        doorbell_state = hass.states.get(doorbell_entity_id)
+        assert doorbell_state is not None
+        assert doorbell_state.attributes.get("event_type") is None
+
+        # Simulate doorbell press start via hub handler
+        msg = MagicMock()
+        msg.data.door_name = "Front Door"
+        msg.data.request_id = "req-abc"
+        await hub._handle_remote_view(msg)
+        await hass.async_block_till_done()
+
+        # The event_type attribute should now be "ring"
+        doorbell_state = hass.states.get(doorbell_entity_id)
+        assert doorbell_state is not None
+        assert doorbell_state.attributes.get("event_type") == "ring"
+
 
 # ---------------------------------------------------------------------------
 # Sensor entities


### PR DESCRIPTION
Closes #217. Added standard 'ring' event type for DoorbellPressedEventEntity alongside legacy unifi_access_doorbell_start and unifi_access_doorbell_stop. Updated all translation files and added unit tests.