### PR TITLE
fix: add open/close/stop commands for UGT 3-button gate/garage covers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,24 +6,31 @@
 
 ## Core integration vs. this HACS integration
 
-Home Assistant now includes a core UniFi Access integration. For most users, the core integration is the recommended starting point.
+Home Assistant now includes a [core UniFi Access integration](https://www.home-assistant.io/integrations/unifi_access/). For most users, the core integration is the recommended starting point — it has met Home Assistant's Platinum quality requirements and is reviewed by core maintainers.
 
-The core integration has met Home Assistant's Platinum quality requirements and any changes to it are reviewed by Home Assistant core maintainers. This provides stronger long-term stability, consistency with Home Assistant architecture, and better alignment with the Home Assistant entity model.
+This HACS integration exists for users who need features that are not available in core, or that don't fit easily into the architectural rules required for Home Assistant core integrations.
 
-This HACS integration will continue to be maintained for the foreseeable future. It exists for users who prefer its current behavior, need features that are not yet available in core, or want functionality that does not fit easily into the architectural rules required for Home Assistant core integrations.
+**Use the core integration** if you want the most official, reviewed, and Home Assistant-native experience.  
+**Use this HACS integration** if you specifically need one of the extras listed below.
 
-In short:
+### Feature comparison
 
-Use the core integration if you want the most official, reviewed, and Home Assistant-native experience.
-Use this HACS integration if you specifically need one of the differences listed below.
-
-Current differences
-The core integration uses button entities/actions for door operations. This follows Home Assistant's entity model more strictly, especially because the UniFi Access API does not currently support locking doors.
-This HACS integration exposes doors as lock entities for convenience. You can unlock/open a door, but locking is unsupported by the UniFi Access API and will only log a warning.
-For UGT doors, this integration can also expose the door as a `cover` entity (`Garage Door` or `Gate`) instead of a `lock`, using a per-door `Entity Type` select.
-Changing a UGT door's entity type updates the relevant entities in place without unloading and reloading the whole integration.
-The core integration supports auto-discovery. This HACS integration does not.
-The core integration may require additional Home Assistant helpers/templates or automations for some workflows that this HACS integration exposes more directly.
+| Feature | Core integration | This HACS integration |
+|---|---|---|
+| Door unlock | `button` entity | `lock` entity (unlock only; locking logs a warning) |
+| Door position sensor | ✅ | ✅ |
+| Doorbell event entity | ✅ | ✅ |
+| Access event entity | ✅ | ✅ |
+| Evacuation / Lockdown switches | ✅ | ✅ |
+| Door lock rules (select + sensor) | ✅ (`set_lock_rule` action) | ✅ (select, number, and sensor entities) |
+| Door thumbnail image | ✅ | ✅ |
+| WebSocket push updates | ✅ | ✅ |
+| Auto-discovery | ✅ | ❌ |
+| Polling mode (for UA controller < 1.90) | ❌ | ✅ |
+| UGT gate / garage door cover entities | ❌ | ✅ (open / close / stop) |
+| UGT entity type selector (lock ↔ garage ↔ gate) | ❌ | ✅ (live swap, no restart needed) |
+| Face Unlock switch (UA-Intercom) | ❌ | ✅ |
+| User management actions (enable / disable / update PIN) | ❌ | ✅ |
 
 # Supported hardware
 - Unifi Access Hub (UAH) :white_check_mark:

--- a/custom_components/unifi_access/cover.py
+++ b/custom_components/unifi_access/cover.py
@@ -45,7 +45,9 @@ async def async_setup_entry(
 class UnifiAccessCoverEntity(UnifiAccessDoorEntity, CoverEntity):
     """Unifi Access Cover Entity (garage door or gate)."""
 
-    _attr_supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+    _attr_supported_features = (
+        CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE | CoverEntityFeature.STOP
+    )
     _attr_name = None
 
     def __init__(self, data: UnifiAccessData, door_id: str) -> None:
@@ -215,7 +217,7 @@ class UnifiAccessCoverEntity(UnifiAccessDoorEntity, CoverEntity):
         self._last_trigger_time = now
         self.door.obstruction_detected = False
 
-        await self._data.hub.client.unlock_door(self.door.id)
+        await self._data.hub.async_open_door(self.door.id)
 
         # Always start the opening timer on an explicit command — sensor state
         # at trigger time may be mid-travel from a preceding close cycle.
@@ -243,7 +245,7 @@ class UnifiAccessCoverEntity(UnifiAccessDoorEntity, CoverEntity):
         self._last_trigger_time = now
         self.door.obstruction_detected = False
 
-        await self._data.hub.client.unlock_door(self.door.id)
+        await self._data.hub.async_close_door(self.door.id)
 
         # Always start the closing timer on an explicit command — sensor state
         # at trigger time may be mid-travel from a preceding open cycle.
@@ -260,6 +262,14 @@ class UnifiAccessCoverEntity(UnifiAccessDoorEntity, CoverEntity):
             self._is_opening = False
             self._is_closing = False
             self._cancel_operation_timer()
+        self.async_write_ha_state()
+
+    async def async_stop_cover(self, **kwargs: Any) -> None:
+        """Stop the cover motor mid-travel (UGT AUX relay)."""
+        await self._data.hub.async_stop_door(self.door.id)
+        self._cancel_operation_timer()
+        self._is_opening = False
+        self._is_closing = False
         self.async_write_ha_state()
 
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/unifi_access/hub.py
+++ b/custom_components/unifi_access/hub.py
@@ -358,6 +358,18 @@ class UnifiAccessHub:
         """Update or remove a user's PIN."""
         await self.client.update_user_pin(user_id, pin)
 
+    async def async_open_door(self, door_id: str) -> None:
+        """Send open command to a UGT gate/garage door."""
+        await self.client.unlock_door(door_id, control_cmd="open")
+
+    async def async_close_door(self, door_id: str) -> None:
+        """Send close command to a UGT gate/garage door."""
+        await self.client.unlock_door(door_id, control_cmd="close")
+
+    async def async_stop_door(self, door_id: str) -> None:
+        """Send stop command to a UGT gate/garage door."""
+        await self.client.unlock_door(door_id, control_cmd="stop")
+
     async def async_close(self) -> None:
         """Close the API client (stops websocket)."""
         await self.client.close()

--- a/custom_components/unifi_access/manifest.json
+++ b/custom_components/unifi_access/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/imhotep/hass-unifi-access/blob/main/README.md",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/imhotep/hass-unifi-access/issues",
-  "requirements": ["py-unifi-access==1.4.0"],
+  "requirements": ["py-unifi-access==1.5.0"],
   "version": "3.0.9"
 }

--- a/custom_components/unifi_access/manifest.json
+++ b/custom_components/unifi_access/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/imhotep/hass-unifi-access/issues",
   "requirements": ["py-unifi-access==1.6.1"],
-  "version": "3.0.12"
+  "version": "3.0.13"
 }

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN, LockState
 from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
@@ -552,3 +553,69 @@ class TestPollingMode:
         """Image entities should NOT exist in polling mode."""
         image_entities = [s for s in hass.states.async_all() if s.domain == "image"]
         assert len(image_entities) == 0
+
+
+# ---------------------------------------------------------------------------
+# Cover entity: open/close/stop send correct control_cmd
+# ---------------------------------------------------------------------------
+
+
+async def _switch_door_to_garage(hass: HomeAssistant) -> str:
+    """Switch door-001 to garage type and return the cover entity_id."""
+    registry = er.async_get(hass)
+    entity_type_id = registry.async_get_entity_id(
+        SELECT_DOMAIN, DOMAIN, "door-001_entity_type"
+    )
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        "select_option",
+        {"entity_id": entity_type_id, "option": "garage"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    return registry.async_get_entity_id("cover", DOMAIN, "door-001_cover")
+
+
+class TestCoverControlCommands:
+    """Cover open/close/stop pass the correct control_cmd to the API."""
+
+    async def test_open_cover_sends_open_cmd(
+        self, hass: HomeAssistant, setup_integration
+    ) -> None:
+        _, mock_client = setup_integration
+        cover_entity_id = await _switch_door_to_garage(hass)
+        assert cover_entity_id is not None
+
+        mock_client.unlock_door.reset_mock()
+        await hass.services.async_call(
+            COVER_DOMAIN, "open_cover", {"entity_id": cover_entity_id}, blocking=True
+        )
+        mock_client.unlock_door.assert_called_once_with("door-001", control_cmd="open")
+
+    async def test_close_cover_sends_close_cmd(
+        self, hass: HomeAssistant, setup_integration
+    ) -> None:
+        _, mock_client = setup_integration
+        cover_entity_id = await _switch_door_to_garage(hass)
+        assert cover_entity_id is not None
+
+        mock_client.unlock_door.reset_mock()
+        await hass.services.async_call(
+            COVER_DOMAIN, "close_cover", {"entity_id": cover_entity_id}, blocking=True
+        )
+        mock_client.unlock_door.assert_called_once_with(
+            "door-001", control_cmd="close"
+        )
+
+    async def test_stop_cover_sends_stop_cmd(
+        self, hass: HomeAssistant, setup_integration
+    ) -> None:
+        _, mock_client = setup_integration
+        cover_entity_id = await _switch_door_to_garage(hass)
+        assert cover_entity_id is not None
+
+        mock_client.unlock_door.reset_mock()
+        await hass.services.async_call(
+            COVER_DOMAIN, "stop_cover", {"entity_id": cover_entity_id}, blocking=True
+        )
+        mock_client.unlock_door.assert_called_once_with("door-001", control_cmd="stop")


### PR DESCRIPTION
## Summary

Fixes two bugs reported in #214 affecting UGT (UniFi Gate Hub) cover entities:

1. **Open and close were identical**: both `async_open_cover` and `async_close_cover` called `client.unlock_door()` with no `control_cmd`, so both sent the same undifferentiated relay pulse — the controller had no way to know whether to open or close
2. **Stop was completely unsupported**: `CoverEntityFeature.STOP` was not declared and there was no `async_stop_cover`

The UniFi Access API already supports `?control_cmd=open|close|stop` as query parameters on the existing unlock endpoint (confirmed by filmgarage's and Luke47-Dev's working `rest_command` workarounds in #214).

## Changes

- Add `async_open_door` / `async_close_door` / `async_stop_door` hub wrappers that pass the correct `control_cmd`
- Update `cover.py` to call these wrappers instead of `client.unlock_door` directly
- Add `CoverEntityFeature.STOP` to `_attr_supported_features`
- Add `async_stop_cover`: sends stop command, cancels running timer, clears opening/closing state
- Bump `py-unifi-access` requirement to 1.5.0 (adds `control_cmd` param to `unlock_door`)

Depends on: https://github.com/imhotep/py-unifi-access/pull/17

## Test plan

- [ ] All 99 existing tests pass
- [ ] New `TestCoverControlCommands` tests verify open/close/stop each call `unlock_door` with the correct `control_cmd`
- [ ] Gate owner (filmgarage / Luke47-Dev from #214) to validate on hardware that open, close, and stop work independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)