### PR TITLE
feat: add FaceUnlockSwitch entity for face-capable readers (issue #213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.12] - 2026-07-19
+
+### Added
+- `Face Unlock` switch entity (`switch.<door>_face_unlock`) for readers that report face unlock capability (e.g. UA-Intercom). The switch enables or disables biometric face unlock per door and is only created for capable devices. State is fetched at startup and updated optimistically on toggle; polling mode refreshes it on each cycle. Requires `py-unifi-access==1.6.1`.
+
 ## [3.0.11] - 2026-07-17
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,149 @@
+# hass-unifi-access
+
+Home Assistant custom integration for UniFi Access. Uses `py-unifi-access` as the API library.
+
+## Virtual environment
+
+```bash
+.venv/bin/python         # Python 3.14
+.venv/bin/python -m pip  # package management
+```
+
+To use a local (dev) build of py-unifi-access:
+
+```bash
+.venv/bin/pip install -e /Users/anis/Documents/Projects/py-unifi-access
+```
+
+## Validation loop
+
+```bash
+.venv/bin/python -m pytest tests/ -v
+```
+
+That's the full loop for hass. No pre-commit/mypy setup in this repo.
+
+## Integration layout
+
+```
+custom_components/unifi_access/
+  __init__.py        # async_setup() for domain services; async_setup_entry() for entry setup
+  hub.py             # UnifiAccessHub — door state, WS events, API calls
+  coordinator.py     # UnifiAccessCoordinator — polling-mode DataUpdateCoordinator
+  entity.py          # UnifiAccessDoorEntity base; manage_door_entities helper
+  config_flow.py     # Config flow UI
+  const.py           # Domain constants and door type strings
+  binary_sensor.py   # Door position, lock status sensors
+  button.py          # Unlock button
+  cover.py           # UGT gate/garage cover (open/close/stop)
+  event.py           # Doorbell / access entry event entities
+  image.py           # Doorbell snapshot image
+  lock.py            # Door lock entity
+  number.py          # Lock rule interval
+  select.py          # Lock rule type selector
+  sensor.py          # Door state sensors
+  switch.py          # Emergency evacuation/lockdown + FaceUnlockSwitch
+  services.yaml      # Service UI metadata (fields, descriptions)
+  strings.json       # Entity/service translation strings
+  manifest.json      # Integration metadata, py-unifi-access version pin
+```
+
+## Data flow
+
+```
+async_setup_entry()
+  → UnifiAccessHub(client)       # wraps API client
+  → UnifiAccessCoordinator       # polls hub in polling mode
+  → UnifiAccessData(hub, coordinator, emergency_coordinator, store)
+       stored in entry.runtime_data
+```
+
+## DoorState (hub.py)
+
+`DoorState` is a mutable dataclass stored in `hub.doors: dict[str, DoorState]` keyed by `door.id`.
+
+Key fields:
+- `door: Door` — immutable API model
+- `hub_id: str | None` — device ID of the hub controlling this door
+- `hub_type: str | None` — device type string (e.g. `"UGT"`, `"UA-Intercom"`)
+- `entity_type: str` — `"door"` or `"cover"` (UGT)
+- `lock_rule: str`, `lock_rule_ended_time: int`, `lock_rule_interval: int`
+- `device_settings: DeviceSettings | None` — fetched for face-capable devices
+- `has_face_unlock: bool` — True if hub device reports `support_face` capability
+
+## Entities wired at setup
+
+`manage_door_entities` (in `entity.py`) takes a predicate and factory and registers/deregisters entities as doors come and go:
+
+```python
+manage_door_entities(
+    config_entry,
+    coordinator,
+    async_add_entities,
+    predicate=lambda door: door.has_face_unlock,
+    factory=lambda door_id: [FaceUnlockSwitch(data, door_id)],
+)
+```
+
+Called in each platform's `async_setup_entry`. Doors that fail the predicate don't get entities.
+
+## Domain services
+
+Registered in `async_setup()` (not `async_setup_entry`) so they apply across all config entries:
+
+- `enable_user` / `disable_user` / `update_user_pin` (user management)
+
+Services use `ConfigEntrySelector` for `config_entry_id`. Schema defined in `__init__.py`, UI strings in `services.yaml` and `strings.json`.
+
+## Hub methods added recently
+
+```python
+# UGT cover control (cover.py)
+hub.async_open_door(door_id)   # control_cmd=open
+hub.async_close_door(door_id)  # control_cmd=close
+hub.async_stop_door(door_id)   # control_cmd=stop
+
+# Face unlock (switch.py)
+hub.async_set_face_unlock(door_id, enabled=True/False)  # PUT device settings + optimistic update
+hub.async_refresh_device_settings()                      # re-fetch all face-capable doors
+```
+
+## Test patterns
+
+```python
+# Patch the API client at import time
+with patch(
+    "custom_components.unifi_access.UnifiAccessApiClient",
+    return_value=mock_client,
+):
+    await hass.config_entries.async_setup(entry.entry_id)
+
+# Domain setup (ConfigType is a type alias, not a class)
+await async_setup(hass, {})
+
+# Entity registry lookups
+registry = er.async_get(hass)
+entity_id = registry.async_get_entity_id("switch", DOMAIN, "door-001_face_unlock")
+```
+
+Sample data fixtures live in `tests/conftest.py`. Add new sample devices/settings there.
+
+## Versions
+
+| Version | Key changes |
+|---------|-------------|
+| 3.0.11  | FaceUnlockSwitch entity (requires py-unifi-access==1.6.0) |
+| 3.0.10  | Bump to py-unifi-access==1.5.0 (1.4.0 was never published) |
+| 3.0.9   | User management actions (enable/disable/update_pin) |
+| 3.0.8   | Changelog / manifest housekeeping |
+| 3.0.7   | UGT door type support |
+
+## Active branches / PRs
+
+- `fix/ugt-cover-stop` (PR #220) — UGT cover open/close/stop (requires py-unifi-access 1.5.0, merged)
+- `feat/device-settings` (PR #222) — FaceUnlockSwitch entity (requires py-unifi-access 1.6.0)
+- `feat/user-management` (PR #219, merged) — user management services
+
+## Library dependency
+
+`manifest.json` pins the exact py-unifi-access version. Always update it when bumping the library. The hass venv must have the matching version installed — install local dev builds with `pip install -e`.

--- a/README.md
+++ b/README.md
@@ -295,8 +295,6 @@ The Unifi Access API does *NOT* support door locking at the moment. You probably
 4. Restart Home Assistant
 5. If you installed via HACS you can also uninstall the repository from HACS afterwards
 
-# Wishlist
-
 # Troubleshooting
 
 ## Invalid API Key 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The core integration may require additional Home Assistant helpers/templates or 
         - a `cover` entity
         - `Opening Timeout` and `Closing Timeout` (`number`) helpers
         - a `Clear Obstruction` (`button`) helper
+    - For **face-capable readers** (e.g. UA-Intercom): a `Face Unlock` (`switch`) entity to enable or disable biometric face unlock per door.
 
 
 # Installation (manual)
@@ -82,6 +83,7 @@ The core integration may require additional Home Assistant helpers/templates or 
         - a `cover` entity
         - `Opening Timeout` and `Closing Timeout` (`number`) helpers
         - a `Clear Obstruction` (`button`) helper
+    - For **face-capable readers** (e.g. UA-Intercom): a `Face Unlock` (`switch`) entity to enable or disable biometric face unlock per door.
 
 # Events
 When websocket mode is enabled (`Use polling` is **not** selected), this integration creates two Home Assistant `event` entities for each door:
@@ -152,6 +154,20 @@ For `Garage Door` and `Gate` cover mode, the integration also adds:
 - `Clear Obstruction` (`button`)
 
 The cover entity uses the same UniFi Access momentary trigger as door unlock/open. The timeout helpers let Home Assistant infer whether the door is still opening or closing and expose an `obstruction_detected` attribute when the sensor state does not match the expected result.
+
+## Face Unlock (UA-Intercom and other face-capable readers)
+
+For readers that report face unlock capability (e.g. UA-Intercom), the integration creates a `Face Unlock` switch entity per door:
+
+- **Entity ID**: `switch.<door_name>_face_unlock`
+- **Icon**: `mdi:face-recognition`
+- **State**: reflects the current `access_methods.face.enabled` setting from the reader
+- **Turn on**: enables biometric face unlock on that reader
+- **Turn off**: disables biometric face unlock on that reader
+
+The switch only appears for readers that support face unlock. Readers without this capability (e.g. standard UAH, UGT) will not have this entity.
+
+State is fetched at startup and updated optimistically on toggle. In polling mode, the state is also refreshed on each poll cycle.
 
 ### Door lock rules (only applies to UAH)
 The following entities will be created: `select`, `number` and 2 `sensor` entities (end time and current rule).

--- a/custom_components/unifi_access/hub.py
+++ b/custom_components/unifi_access/hub.py
@@ -20,6 +20,7 @@ from unifi_access_api import (
     ApiNotFoundError,
     BaseInfo,
     Device,
+    DeviceSettings,
     DeviceUpdate,
     Door,
     DoorLockRelayStatus,
@@ -82,6 +83,8 @@ class DoorState:
     doorbell_request_id: str | None = None
     thumbnail: bytes | None = None
     thumbnail_last_updated: datetime | None = None
+    device_settings: DeviceSettings | None = None
+    has_face_unlock: bool = False
 
     _event_listeners: dict[str, list[EventListener]] = field(
         default_factory=dict, repr=False
@@ -200,6 +203,8 @@ class UnifiAccessHub:
             # Populate hub_type from the devices API at startup instead of
             # waiting for a later device update websocket event.
             await self._async_map_hub_types()
+        else:
+            await self.async_refresh_device_settings()
         return self.doors
 
     @staticmethod
@@ -243,6 +248,32 @@ class UnifiAccessHub:
             "Hub type mapping: %s",
             {k: (v.hub_type, v.hub_id) for k, v in self.doors.items()},
         )
+
+        # Mark doors whose hub device supports face unlock, then fetch settings.
+        face_capable_capabilities = {"support_face", "identity_face_unlock"}
+        face_doors: list[tuple[str, str]] = []
+        for device in devices:
+            if not self._is_hub_device(device):
+                continue
+            caps = set(getattr(device, "capabilities", []))
+            if caps & face_capable_capabilities and device.location_id in self.doors:
+                self.doors[device.location_id].has_face_unlock = True
+                face_doors.append((device.location_id, device.id))
+
+        if face_doors:
+            results = await asyncio.gather(
+                *(self.client.get_device_settings(dev_id) for _, dev_id in face_doors),
+                return_exceptions=True,
+            )
+            for (door_id, _), result in zip(face_doors, results):
+                if isinstance(result, DeviceSettings):
+                    self.doors[door_id].device_settings = result
+                else:
+                    _LOGGER.warning(
+                        "Could not fetch device settings for door %s: %s",
+                        door_id,
+                        result,
+                    )
 
     def _resolve_door_state(
         self,
@@ -357,6 +388,43 @@ class UnifiAccessHub:
     async def async_update_user_pin(self, user_id: str, pin: str | None) -> None:
         """Update or remove a user's PIN."""
         await self.client.update_user_pin(user_id, pin)
+
+    async def async_set_face_unlock(self, door_id: str, *, enabled: bool) -> None:
+        """Enable or disable face unlock on a device."""
+        state = self.doors[door_id]
+        value = "yes" if enabled else "no"
+        await self.client.put_device_settings(
+            state.hub_id,
+            {"face": {"enabled": value}},
+        )
+        if state.device_settings is not None:
+            updated_face = state.device_settings.access_methods.face.model_copy(
+                update={"enabled": value}
+            )
+            updated_methods = state.device_settings.access_methods.model_copy(
+                update={"face": updated_face}
+            )
+            state.device_settings = state.device_settings.model_copy(
+                update={"access_methods": updated_methods}
+            )
+        self._notify_doors_updated()
+
+    async def async_refresh_device_settings(self) -> None:
+        """Re-fetch device settings for all face-capable doors."""
+        face_doors = [
+            (door_id, state.hub_id)
+            for door_id, state in self.doors.items()
+            if state.has_face_unlock and state.hub_id
+        ]
+        if not face_doors:
+            return
+        results = await asyncio.gather(
+            *(self.client.get_device_settings(hub_id) for _, hub_id in face_doors),
+            return_exceptions=True,
+        )
+        for (door_id, _), result in zip(face_doors, results):
+            if isinstance(result, DeviceSettings):
+                self.doors[door_id].device_settings = result
 
     async def async_close(self) -> None:
         """Close the API client (stops websocket)."""

--- a/custom_components/unifi_access/manifest.json
+++ b/custom_components/unifi_access/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/imhotep/hass-unifi-access/blob/main/README.md",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/imhotep/hass-unifi-access/issues",
-  "requirements": ["py-unifi-access==1.5.0"],
-  "version": "3.0.10"
+  "requirements": ["py-unifi-access==1.6.0"],
+  "version": "3.0.11"
 }

--- a/custom_components/unifi_access/strings.json
+++ b/custom_components/unifi_access/strings.json
@@ -175,6 +175,9 @@
       "evacuation": {
         "name": "Evacuation"
       },
+      "face_unlock": {
+        "name": "Face Unlock"
+      },
       "lockdown": {
         "name": "Lockdown"
       }

--- a/custom_components/unifi_access/switch.py
+++ b/custom_components/unifi_access/switch.py
@@ -9,9 +9,10 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from unifi_access_api import EmergencyStatus
 
-from . import UnifiAccessConfigEntry
+from . import UnifiAccessConfigEntry, UnifiAccessData
 from .const import DOMAIN
 from .coordinator import UnifiAccessCoordinator
+from .entity import UnifiAccessDoorEntity, manage_door_entities
 from .hub import UnifiAccessHub
 
 PARALLEL_UPDATES = 1
@@ -41,6 +42,13 @@ async def async_setup_entry(
                 translation_key="lockdown",
             ),
         ]
+    )
+    manage_door_entities(
+        config_entry,
+        data.coordinator,
+        async_add_entities,
+        lambda door: door.has_face_unlock,
+        lambda door_id: [FaceUnlockSwitch(data, door_id)],
     )
 
 
@@ -87,3 +95,31 @@ class EmergencySwitch(CoordinatorEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on emergency mode."""
         await self.hub.async_set_emergency_status(**{self._field: True})
+
+
+class FaceUnlockSwitch(UnifiAccessDoorEntity, SwitchEntity):
+    """Switch to enable or disable face unlock on a UniFi reader device."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "face_unlock"
+    _attr_icon = "mdi:face-recognition"
+
+    def __init__(self, data: UnifiAccessData, door_id: str) -> None:
+        """Initialize the face unlock switch."""
+        super().__init__(data.coordinator, data.coordinator.data[door_id])
+        self._data = data
+        self._attr_unique_id = f"{door_id}_face_unlock"
+
+    @property
+    def is_on(self) -> bool:
+        """Return True when face unlock is enabled on the device."""
+        settings = self.door.device_settings
+        return settings is not None and settings.access_methods.face.is_enabled
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable face unlock."""
+        await self._data.hub.async_set_face_unlock(self.door.id, enabled=True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable face unlock."""
+        await self._data.hub.async_set_face_unlock(self.door.id, enabled=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from unifi_access_api import (
     Device,
+    DeviceSettings,
     Door,
     DoorLockRelayStatus,
     DoorLockRuleStatus,
@@ -28,6 +29,7 @@ from unifi_access_api import (
     DoorPositionStatus,
     EmergencyStatus,
 )
+from unifi_access_api.models.device_settings import AccessMethods, FaceAccessMethod
 
 from custom_components.unifi_access.const import DOMAIN
 
@@ -112,6 +114,31 @@ SAMPLE_DEVICES = [
     ),
 ]
 
+SAMPLE_DEVICES_WITH_FACE = [
+    Device(
+        id="hub-intercom-001",
+        type="UA-Intercom",
+        location_id="door-001",
+        capabilities=["is_hub", "support_face", "identity_face_unlock"],
+    ),
+    Device(
+        id="hub-mini-001",
+        type="UA-Hub-Door-Mini",
+        location_id="door-002",
+        capabilities=["is_hub"],
+    ),
+]
+
+SAMPLE_DEVICE_SETTINGS_FACE_OFF = DeviceSettings(
+    device_id="hub-intercom-001",
+    access_methods=AccessMethods(face=FaceAccessMethod(enabled="no")),
+)
+
+SAMPLE_DEVICE_SETTINGS_FACE_ON = DeviceSettings(
+    device_id="hub-intercom-001",
+    access_methods=AccessMethods(face=FaceAccessMethod(enabled="yes")),
+)
+
 SAMPLE_DEVICE_DOOR_MAP = {device.id: device.location_id for device in SAMPLE_DEVICES}
 
 SAMPLE_LOCK_RULE_STATUS = DoorLockRuleStatus(
@@ -167,6 +194,8 @@ def mock_api_client() -> AsyncMock:
     client.get_device_door_map = AsyncMock(return_value=SAMPLE_DEVICE_DOOR_MAP)
     client.resolve_door_id = MagicMock(side_effect=SAMPLE_DEVICE_DOOR_MAP.get)
     client.get_thumbnail = AsyncMock(return_value=b"fake-image-bytes")
+    client.get_device_settings = AsyncMock(return_value=SAMPLE_DEVICE_SETTINGS_FACE_OFF)
+    client.put_device_settings = AsyncMock()
     client.start_websocket = MagicMock()
     client.close = AsyncMock()
     return client

--- a/tests/test_face_unlock.py
+++ b/tests/test_face_unlock.py
@@ -1,0 +1,157 @@
+"""Tests for FaceUnlockSwitch entity."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.unifi_access.const import DOMAIN
+
+from .conftest import (
+    MOCK_CONFIG,
+    SAMPLE_DEVICE_DOOR_MAP,
+    SAMPLE_DEVICES,
+    SAMPLE_DEVICES_WITH_FACE,
+    SAMPLE_DEVICE_SETTINGS_FACE_OFF,
+    SAMPLE_DEVICE_SETTINGS_FACE_ON,
+    SAMPLE_DOORS,
+    SAMPLE_EMERGENCY_STATUS,
+    SAMPLE_LOCK_RULE_STATUS,
+)
+
+
+def _make_mock_client(*, face_capable: bool = False) -> AsyncMock:
+    client = AsyncMock()
+    client.authenticate = AsyncMock()
+    client.get_doors = AsyncMock(return_value=SAMPLE_DOORS)
+    client.get_door_lock_rule = AsyncMock(return_value=SAMPLE_LOCK_RULE_STATUS)
+    client.get_emergency_status = AsyncMock(return_value=SAMPLE_EMERGENCY_STATUS)
+    client.set_emergency_status = AsyncMock()
+    client.unlock_door = AsyncMock()
+    devices = SAMPLE_DEVICES_WITH_FACE if face_capable else SAMPLE_DEVICES
+    client.get_devices = AsyncMock(return_value=devices)
+    device_door_map = {d.id: d.location_id for d in devices}
+    client.get_device_door_map = AsyncMock(return_value=device_door_map)
+    client.resolve_door_id = MagicMock(side_effect=device_door_map.get)
+    client.get_device_settings = AsyncMock(return_value=SAMPLE_DEVICE_SETTINGS_FACE_OFF)
+    client.put_device_settings = AsyncMock()
+    client.start_websocket = MagicMock()
+    client.close = AsyncMock()
+    return client
+
+
+async def _setup(hass: HomeAssistant, mock_client: AsyncMock) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG,
+        unique_id="192.168.1.1",
+        title="Unifi Access",
+    )
+    entry.add_to_hass(hass)
+    with (
+        patch(
+            "custom_components.unifi_access.UnifiAccessApiClient",
+            return_value=mock_client,
+        ),
+        patch(
+            "custom_components.unifi_access.async_get_clientsession",
+            return_value=AsyncMock(),
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+async def test_face_unlock_switch_created_for_capable_device(
+    hass: HomeAssistant,
+) -> None:
+    """FaceUnlockSwitch is created when the hub device has support_face capability."""
+    mock_client = _make_mock_client(face_capable=True)
+    await _setup(hass, mock_client)
+
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id("switch", DOMAIN, "door-001_face_unlock")
+    assert entity_id is not None
+    state = hass.states.get(entity_id)
+    assert state is not None
+
+
+async def test_face_unlock_switch_not_created_for_incapable_device(
+    hass: HomeAssistant,
+) -> None:
+    """FaceUnlockSwitch is NOT created when the device has no face capability."""
+    mock_client = _make_mock_client(face_capable=False)
+    await _setup(hass, mock_client)
+
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id("switch", DOMAIN, "door-001_face_unlock")
+    assert entity_id is None
+
+
+async def test_face_unlock_initial_state_off(hass: HomeAssistant) -> None:
+    """Switch initial state reflects device settings (face disabled)."""
+    mock_client = _make_mock_client(face_capable=True)
+    mock_client.get_device_settings = AsyncMock(
+        return_value=SAMPLE_DEVICE_SETTINGS_FACE_OFF
+    )
+    await _setup(hass, mock_client)
+
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id("switch", DOMAIN, "door-001_face_unlock")
+    assert hass.states.get(entity_id).state == "off"
+
+
+async def test_face_unlock_initial_state_on(hass: HomeAssistant) -> None:
+    """Switch initial state reflects device settings (face enabled)."""
+    mock_client = _make_mock_client(face_capable=True)
+    mock_client.get_device_settings = AsyncMock(
+        return_value=SAMPLE_DEVICE_SETTINGS_FACE_ON
+    )
+    await _setup(hass, mock_client)
+
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id("switch", DOMAIN, "door-001_face_unlock")
+    assert hass.states.get(entity_id).state == "on"
+
+
+async def test_turn_on_calls_put_device_settings(hass: HomeAssistant) -> None:
+    """Turning on calls put_device_settings with face enabled=yes."""
+    mock_client = _make_mock_client(face_capable=True)
+    await _setup(hass, mock_client)
+
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id("switch", DOMAIN, "door-001_face_unlock")
+
+    mock_client.put_device_settings.reset_mock()
+    await hass.services.async_call(
+        SWITCH_DOMAIN, "turn_on", {"entity_id": entity_id}, blocking=True
+    )
+    mock_client.put_device_settings.assert_called_once_with(
+        "hub-intercom-001", {"face": {"enabled": "yes"}}
+    )
+
+
+async def test_turn_off_calls_put_device_settings(hass: HomeAssistant) -> None:
+    """Turning off calls put_device_settings with face enabled=no."""
+    mock_client = _make_mock_client(face_capable=True)
+    mock_client.get_device_settings = AsyncMock(
+        return_value=SAMPLE_DEVICE_SETTINGS_FACE_ON
+    )
+    await _setup(hass, mock_client)
+
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id("switch", DOMAIN, "door-001_face_unlock")
+
+    mock_client.put_device_settings.reset_mock()
+    await hass.services.async_call(
+        SWITCH_DOMAIN, "turn_off", {"entity_id": entity_id}, blocking=True
+    )
+    mock_client.put_device_settings.assert_called_once_with(
+        "hub-intercom-001", {"face": {"enabled": "no"}}
+    )


### PR DESCRIPTION
## Summary

Closes #213.

Adds a `switch.<door>_face_unlock` entity for any UniFi reader that reports `support_face` or `identity_face_unlock` in its device capabilities (e.g. UA-Intercom).

- **Discovery**: checked at startup via device capabilities; `DoorState.has_face_unlock` gates entity creation through `manage_door_entities`
- **Initial state**: fetched from `GET /api/v1/developer/devices/{id}/settings` at startup (concurrently for all capable devices)
- **Toggle**: calls `PUT /api/v1/developer/devices/{id}/settings` with a partial `access_methods.face.enabled` payload; state updated optimistically, no re-fetch needed
- **Polling mode**: `async_refresh_device_settings()` is called on each coordinator poll to keep state current
- **WebSocket mode**: optimistic updates cover toggles; live WS updates for device settings deferred to a follow-up once the event payload shape is confirmed
- Icon: `mdi:face-recognition`

Depends on: https://github.com/imhotep/py-unifi-access/pull/18 (py-unifi-access 1.6.0)

## Test plan

- [ ] 102 tests pass (6 new in `tests/test_face_unlock.py`)
- [ ] Switch appears only for face-capable devices
- [ ] Switch absent for non-capable devices
- [ ] Initial state OFF/ON reflects device settings
- [ ] Turn on → `put_device_settings` called with `enabled: "yes"`
- [ ] Turn off → `put_device_settings` called with `enabled: "no"`
- [ ] Manual validation requested from issue #213 reporter (UA-Intercom hardware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)