### PR TITLE
fix: user management actions (enable/disable/update_pin) — bump to 3.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.11] - 2026-07-17
+
+### Fixed
+- User management actions (`enable_user`, `disable_user`, `update_user_pin`) now work correctly. The underlying `py-unifi-access` library was using the wrong HTTP method (`PATCH`) and wrong status values (`active`/`inactive`) — the UniFi Access API only supports `GET`/`POST`/`PUT`/`DELETE`, and status values are `ACTIVE`/`DEACTIVATED`. The `update_user_pin` action was also sending to the wrong endpoint; it now uses `PUT /users/:id/pin_codes` to assign and `DELETE /users/:id/pin_codes` to remove. Requires `py-unifi-access==1.6.1`.
+
 ## [3.0.10] - 2026-07-17
 
 ### Fixed

--- a/custom_components/unifi_access/manifest.json
+++ b/custom_components/unifi_access/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/imhotep/hass-unifi-access/blob/main/README.md",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/imhotep/hass-unifi-access/issues",
-  "requirements": ["py-unifi-access==1.5.0"],
-  "version": "3.0.10"
+  "requirements": ["py-unifi-access==1.6.1"],
+  "version": "3.0.11"
 }


### PR DESCRIPTION
## Summary

- Bumps `py-unifi-access` requirement to `1.6.1`
- Bumps integration version to `3.0.11`

The user management actions (`enable_user`, `disable_user`, `update_user_pin`) were broken in production with a 404 error. Root cause was in `py-unifi-access`:

- Wrong HTTP method: `PATCH` is not supported by the UniFi Access API (only GET/POST/PUT/DELETE per official API docs)
- Wrong status values: `"active"/"inactive"` → `"ACTIVE"/"DEACTIVATED"`
- `update_user_pin` sent to wrong endpoint (`/users/:id`) → now `PUT /users/:id/pin_codes` to assign, `DELETE /users/:id/pin_codes` to remove

Fixed in py-unifi-access PR #19, released as 1.6.1.

## Test plan

- [ ] 96 tests pass
- [ ] `enable_user` / `disable_user` service calls succeed on a real device
- [ ] `update_user_pin` assigns and removes a PIN correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)