### PR TITLE
feat: include guard_ids in doorbell events for UA-Intercom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `reader_id` and `reader_name` attributes on Door Event entities. When the controller reports which physical reader processed an access event, these fields expose the reader's MAC/device ID and display name (e.g. `UA-G2-PRO-BB7A`). Useful for automations that need to distinguish between multiple readers on the same door (e.g. inside vs. outside). Only present when the controller provides reader data; omitted otherwise.
+
 ## [3.0.13] - 2026-07-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -150,11 +150,13 @@ One `Door Event` entity is created per door. It updates whenever the integration
 ### Event metadata
 - `door_name`
 - `door_id`
-- `actor` # the user tied to the event, when available
-- `authentication` # authentication source reported by the controller
-- `method` # opened method, when provided by the controller
+- `actor` — the user tied to the event, when available
+- `authentication` — authentication source reported by the controller
+- `method` — opened method, when provided by the controller
 - `type`
-- `result` # examples: `ACCESS`, `BLOCKED`, `INCOMPLETE`
+- `result` — examples: `ACCESS`, `BLOCKED`, `INCOMPLETE`
+- `reader_id` — MAC address / device ID of the reader that processed the event. Only present when the controller reports reader data.
+- `reader_name` — display name of that reader (e.g. `UA-G2-PRO-BB7A`). Only present when the controller reports reader data.
 
 #### Warning regarding Door Events
 Door events are using an undocumented API. Sadly, in September 2025, the Unifi Access API introduced some bugs that we have worked around but these events are still not 100% reliable depending on your hub. I recommend using the [Alarm Manager webhooks](https://github.com/imhotep/hass-unifi-access/issues/185#issuecomment-3895814140) if you need a more reliable way to automate based on door events.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ One `Doorbell Press` entity is created per door. It updates when the integration
 - `door_name`
 - `door_id`
 - `type`
+- `guard_ids` (list of UUIDs) — IDs of the tenant/unit that rang the doorbell. **UA-Intercom only**, only present when non-empty. Cross-reference with the UniFi Access Users API to resolve to names.
 
 For hardware doorbells, the integration may emit `unifi_access_doorbell_stop` automatically after a short delay if no explicit stop event is received.
 

--- a/custom_components/unifi_access/const.py
+++ b/custom_components/unifi_access/const.py
@@ -12,6 +12,9 @@ DOOR_TYPES = [DOOR_TYPE_LOCK, DOOR_TYPE_GARAGE, DOOR_TYPE_GATE]
 STORAGE_KEY = "unifi_access_entity_types"
 STORAGE_VERSION = 1
 
+# Hub types that support the intercom guard ID feature (UA-Intercom directory)
+INTERCOM_HUB_TYPES: frozenset[str] = frozenset({"UA-Intercom", "UA-G3-Intercom"})
+
 # Doorbell event types
 DOORBELL_EVENT = "doorbell_press"
 DOORBELL_START_EVENT = "unifi_access_doorbell_start"

--- a/custom_components/unifi_access/hub.py
+++ b/custom_components/unifi_access/hub.py
@@ -719,7 +719,7 @@ class UnifiAccessHub:
         method_entries = update.data.metadata.opened_method
         method = method_entries[0].display_name if method_entries else ""
 
-        event_attributes = {
+        event_attributes: dict[str, object] = {
             "door_name": state.name,
             "door_id": state.id,
             "actor": update.data.metadata.actor.display_name,
@@ -728,6 +728,10 @@ class UnifiAccessHub:
             "method": method,
             "result": update.data.result,
         }
+        reader_entries = update.data.metadata.reader_capture
+        if reader_entries:
+            event_attributes["reader_id"] = reader_entries[0].id
+            event_attributes["reader_name"] = reader_entries[0].display_name
         _LOGGER.info(
             "Insight: %s on %s (%s) by %s via %s: %s",
             update.data.event_type,

--- a/custom_components/unifi_access/hub.py
+++ b/custom_components/unifi_access/hub.py
@@ -529,7 +529,7 @@ class UnifiAccessHub:
             "door_id": state.id,
             "type": DOORBELL_START_EVENT,
         }
-        if state.hub_type in INTERCOM_HUB_TYPES and update.data.door_guard_ids:
+        if update.data.device_type in INTERCOM_HUB_TYPES and update.data.door_guard_ids:
             event_attributes["guard_ids"] = update.data.door_guard_ids
         _LOGGER.info(
             "Doorbell press on %s request id %s",

--- a/custom_components/unifi_access/hub.py
+++ b/custom_components/unifi_access/hub.py
@@ -51,6 +51,7 @@ from .const import (
     DOOR_TYPE_LOCK,
     DOORBELL_START_EVENT,
     DOORBELL_STOP_EVENT,
+    INTERCOM_HUB_TYPES,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -523,11 +524,13 @@ class UnifiAccessHub:
             return
 
         state.doorbell_request_id = update.data.request_id
-        event_attributes = {
+        event_attributes: dict[str, object] = {
             "door_name": state.name,
             "door_id": state.id,
             "type": DOORBELL_START_EVENT,
         }
+        if state.hub_type in INTERCOM_HUB_TYPES and update.data.door_guard_ids:
+            event_attributes["guard_ids"] = update.data.door_guard_ids
         _LOGGER.info(
             "Doorbell press on %s request id %s",
             door_name,

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -274,11 +274,11 @@ class TestHubWebSocketHandlers:
     async def test_handle_remote_view_guard_ids_included_for_intercom(
         self, hub: UnifiAccessHub
     ) -> None:
-        """guard_ids included in event attributes for UA-Intercom with non-empty list."""
-        hub.doors["door-001"].hub_type = "UA-Intercom"
+        """guard_ids included when the reporting device_type is UA-Intercom."""
         msg = MagicMock()
         msg.data.door_name = "Front Door"
         msg.data.request_id = "req-abc"
+        msg.data.device_type = "UA-Intercom"
         msg.data.door_guard_ids = ["guard-uuid-1", "guard-uuid-2"]
 
         events_received: list[tuple[str, dict]] = []
@@ -295,10 +295,10 @@ class TestHubWebSocketHandlers:
         self, hub: UnifiAccessHub
     ) -> None:
         """guard_ids not added when door_guard_ids is empty."""
-        hub.doors["door-001"].hub_type = "UA-Intercom"
         msg = MagicMock()
         msg.data.door_name = "Front Door"
         msg.data.request_id = "req-abc"
+        msg.data.device_type = "UA-Intercom"
         msg.data.door_guard_ids = []
 
         events_received: list[tuple[str, dict]] = []
@@ -314,11 +314,11 @@ class TestHubWebSocketHandlers:
     async def test_handle_remote_view_guard_ids_excluded_for_non_intercom(
         self, hub: UnifiAccessHub
     ) -> None:
-        """guard_ids not added for non-intercom hub types even if data is present."""
-        hub.doors["door-001"].hub_type = "UAH"
+        """guard_ids not added when the reporting device_type is not an intercom."""
         msg = MagicMock()
         msg.data.door_name = "Front Door"
         msg.data.request_id = "req-abc"
+        msg.data.device_type = "UAH"
         msg.data.door_guard_ids = ["guard-uuid-1"]
 
         events_received: list[tuple[str, dict]] = []
@@ -330,6 +330,28 @@ class TestHubWebSocketHandlers:
 
         assert len(events_received) == 1
         assert "guard_ids" not in events_received[0][1]
+
+    async def test_handle_remote_view_guard_ids_intercom_with_separate_lock_hub(
+        self, hub: UnifiAccessHub
+    ) -> None:
+        """guard_ids included when door's hub_type is a lock hub but the remote_view
+        payload reports device_type=UA-Intercom (Intercom + separate lock hub topology)."""
+        hub.doors["door-001"].hub_type = "UA-Hub-Door-Mini"
+        msg = MagicMock()
+        msg.data.door_name = "Front Door"
+        msg.data.request_id = "req-abc"
+        msg.data.device_type = "UA-Intercom"
+        msg.data.door_guard_ids = ["guard-uuid-1"]
+
+        events_received: list[tuple[str, dict]] = []
+        hub.doors["door-001"].add_event_listener(
+            "doorbell_press", lambda e, a: events_received.append((e, a))
+        )
+
+        await hub._handle_remote_view(msg)
+
+        assert len(events_received) == 1
+        assert events_received[0][1]["guard_ids"] == ["guard-uuid-1"]
 
     async def test_handle_remote_view_change(self, hub: UnifiAccessHub) -> None:
         """Test doorbell press stop handler."""

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -271,6 +271,66 @@ class TestHubWebSocketHandlers:
         assert len(events_received) == 1
         hub.on_doors_updated.assert_called_once()
 
+    async def test_handle_remote_view_guard_ids_included_for_intercom(
+        self, hub: UnifiAccessHub
+    ) -> None:
+        """guard_ids included in event attributes for UA-Intercom with non-empty list."""
+        hub.doors["door-001"].hub_type = "UA-Intercom"
+        msg = MagicMock()
+        msg.data.door_name = "Front Door"
+        msg.data.request_id = "req-abc"
+        msg.data.door_guard_ids = ["guard-uuid-1", "guard-uuid-2"]
+
+        events_received: list[tuple[str, dict]] = []
+        hub.doors["door-001"].add_event_listener(
+            "doorbell_press", lambda e, a: events_received.append((e, a))
+        )
+
+        await hub._handle_remote_view(msg)
+
+        assert len(events_received) == 1
+        assert events_received[0][1]["guard_ids"] == ["guard-uuid-1", "guard-uuid-2"]
+
+    async def test_handle_remote_view_guard_ids_excluded_when_empty(
+        self, hub: UnifiAccessHub
+    ) -> None:
+        """guard_ids not added when door_guard_ids is empty."""
+        hub.doors["door-001"].hub_type = "UA-Intercom"
+        msg = MagicMock()
+        msg.data.door_name = "Front Door"
+        msg.data.request_id = "req-abc"
+        msg.data.door_guard_ids = []
+
+        events_received: list[tuple[str, dict]] = []
+        hub.doors["door-001"].add_event_listener(
+            "doorbell_press", lambda e, a: events_received.append((e, a))
+        )
+
+        await hub._handle_remote_view(msg)
+
+        assert len(events_received) == 1
+        assert "guard_ids" not in events_received[0][1]
+
+    async def test_handle_remote_view_guard_ids_excluded_for_non_intercom(
+        self, hub: UnifiAccessHub
+    ) -> None:
+        """guard_ids not added for non-intercom hub types even if data is present."""
+        hub.doors["door-001"].hub_type = "UAH"
+        msg = MagicMock()
+        msg.data.door_name = "Front Door"
+        msg.data.request_id = "req-abc"
+        msg.data.door_guard_ids = ["guard-uuid-1"]
+
+        events_received: list[tuple[str, dict]] = []
+        hub.doors["door-001"].add_event_listener(
+            "doorbell_press", lambda e, a: events_received.append((e, a))
+        )
+
+        await hub._handle_remote_view(msg)
+
+        assert len(events_received) == 1
+        assert "guard_ids" not in events_received[0][1]
+
     async def test_handle_remote_view_change(self, hub: UnifiAccessHub) -> None:
         """Test doorbell press stop handler."""
         hub.doors["door-001"].doorbell_request_id = "req-abc"

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -393,6 +393,7 @@ class TestHubWebSocketHandlers:
         msg.data.metadata.authentication.display_name = "FACE"
         msg.data.metadata.opened_method = [MagicMock(display_name="face")]
         msg.data.metadata.opened_direction = [MagicMock(display_name="entry")]
+        msg.data.metadata.reader_capture = []
         msg.data.event_type = "access.door.unlock"
         msg.data.result = "ACCESS"
 
@@ -409,7 +410,60 @@ class TestHubWebSocketHandlers:
         assert events_received[0][1]["type"] == "unifi_access_entry"
         assert events_received[0][1]["method"] == "face"
         assert events_received[0][1]["result"] == "ACCESS"
+        assert "reader_id" not in events_received[0][1]
         hub.on_doors_updated.assert_not_called()
+
+    async def test_handle_insights_add_reader_capture_included(
+        self, hub: UnifiAccessHub
+    ) -> None:
+        """reader_id and reader_name are included when reader_capture is non-empty."""
+        msg = MagicMock()
+        msg.data.metadata.door = [MagicMock(id="door-001")]
+        msg.data.metadata.actor.display_name = "Raphael"
+        msg.data.metadata.authentication.display_name = "NFC"
+        msg.data.metadata.opened_method = [MagicMock(display_name="nfc")]
+        msg.data.metadata.opened_direction = [MagicMock(display_name="entry")]
+        msg.data.metadata.reader_capture = [
+            MagicMock(id="AA:BB:CC:DD:EE:FF", display_name="UA-G2-PRO-BB7A")
+        ]
+        msg.data.event_type = "access.door.unlock"
+        msg.data.result = "ACCESS"
+
+        events_received = []
+        hub.doors["door-001"].add_event_listener(
+            "access", lambda e, a: events_received.append(a)
+        )
+
+        await hub._handle_insights_add(msg)
+
+        assert len(events_received) == 1
+        assert events_received[0]["reader_id"] == "AA:BB:CC:DD:EE:FF"
+        assert events_received[0]["reader_name"] == "UA-G2-PRO-BB7A"
+
+    async def test_handle_insights_add_reader_capture_empty(
+        self, hub: UnifiAccessHub
+    ) -> None:
+        """reader_id and reader_name are omitted when reader_capture is empty."""
+        msg = MagicMock()
+        msg.data.metadata.door = [MagicMock(id="door-001")]
+        msg.data.metadata.actor.display_name = "Raphael"
+        msg.data.metadata.authentication.display_name = "NFC"
+        msg.data.metadata.opened_method = [MagicMock(display_name="nfc")]
+        msg.data.metadata.opened_direction = [MagicMock(display_name="entry")]
+        msg.data.metadata.reader_capture = []
+        msg.data.event_type = "access.door.unlock"
+        msg.data.result = "ACCESS"
+
+        events_received = []
+        hub.doors["door-001"].add_event_listener(
+            "access", lambda e, a: events_received.append(a)
+        )
+
+        await hub._handle_insights_add(msg)
+
+        assert len(events_received) == 1
+        assert "reader_id" not in events_received[0]
+        assert "reader_name" not in events_received[0]
 
     async def test_handle_insights_add_unknown_door(self, hub: UnifiAccessHub) -> None:
         """Ignore insights for unknown doors."""
@@ -431,6 +485,7 @@ class TestHubWebSocketHandlers:
         msg.data.metadata.authentication.display_name = "FACE"
         msg.data.metadata.opened_method = [MagicMock(display_name="face")]
         msg.data.metadata.opened_direction = [MagicMock(display_name="entry")]
+        msg.data.metadata.reader_capture = []
         msg.data.event_type = "access.door.unlock"
         msg.data.result = "ACCESS"
 
@@ -461,6 +516,7 @@ class TestHubWebSocketHandlers:
         insight_msg.data.metadata.authentication.display_name = "FACE"
         insight_msg.data.metadata.opened_method = [MagicMock(display_name="face")]
         insight_msg.data.metadata.opened_direction = [MagicMock(display_name="entry")]
+        insight_msg.data.metadata.reader_capture = []
         insight_msg.data.event_type = "access.door.unlock"
         insight_msg.data.result = "ACCESS"
 
@@ -737,6 +793,7 @@ class TestHubWebSocketHandlers:
         msg.data.metadata.authentication.display_name = "NFC"
         msg.data.metadata.opened_method = [MagicMock(display_name="nfc")]
         msg.data.metadata.opened_direction = [MagicMock(display_name="")]
+        msg.data.metadata.reader_capture = []
         msg.data.event_type = "access.door.unlock"
         msg.data.result = "ACCESS"
 
@@ -761,6 +818,7 @@ class TestHubWebSocketHandlers:
         msg.data.metadata.authentication.display_name = "NFC"
         msg.data.metadata.opened_method = [MagicMock(display_name="nfc")]
         msg.data.metadata.opened_direction = [MagicMock(display_name="denied")]
+        msg.data.metadata.reader_capture = []
         msg.data.event_type = "access.door.unlock"
         msg.data.result = "ACCESS"
 


### PR DESCRIPTION
## Summary

Closes #115.

The `access.remote_view` WebSocket event includes a `door_guard_ids` field — a list of UUIDs identifying which tenant/unit rang the doorbell. In a multi-tenant UA-Intercom setup (directory mode), this lets automations target a specific unit instead of every apartment's automation firing on every ring.

- `guard_ids` is added to doorbell press event attributes only for `UA-Intercom` and `UA-G3-Intercom` hub types, and only when non-empty
- All other door types are completely unaffected
- The `door_guard_ids` field was already parsed by py-unifi-access (`RemoteViewData.door_guard_ids: list[str]`) — no library changes needed
- This field is not in the official API docs (no WebSocket section exists); confirmed reliable by @tomweader via hardware testing (own unit vs. neighbour's unit, IDs differed correctly)

## Usage

```yaml
trigger:
  - platform: event
    event_type: unifi_access_doorbell_start
    event_data:
      guard_ids:
        - "b6a29065-b7fe-438c-b9b8-c921bb71cb01"  # Unit 3B
```

Cross-reference guard UUIDs with the UniFi Access Users API to resolve to names.

## Test plan

- [x] 108 tests pass (3 new in `test_hub.py`)
- [x] `guard_ids` present for UA-Intercom with non-empty field
- [x] `guard_ids` absent when field is empty
- [x] `guard_ids` absent for non-intercom hub types
- [ ] Manual validation requested from @tomweader (issue #115, has UA-Intercom hardware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)